### PR TITLE
Use up-to-date rmc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 .idea
 
-venv
+.venv/
 
-data/**
-export/**
-
-notes.md
+data/
+export/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sébastien Kerbourc'h
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include rmtree/templates/*.svg

--- a/README.md
+++ b/README.md
@@ -1,26 +1,42 @@
-reMarkable2pdf
+rmtree
 ===
 
-__**This project is still in an early stage and have significant shortcomings.**__
-
-Command line tool to convert the files in `/home/root/.local/share/remarkable/xochitl/` of
+A command line tool to convert the files in `/home/root/.local/share/remarkable/xochitl/` of
 the [reMarkable 2](https://remarkable.com/) to PDFs.
 
-**It is only compatible with `.rm` v6.**
+**It is only compatible with `.rm` version 6
+and `.content` version 1 and 2 _(`"formatVersion": 2` or `"formatVersion": 1`)_.**
 
-## Constraints
+It uses [rmc](https://github.com/ricklupton/rmc) (which depends on [rmscene](https://github.com/ricklupton/rmscene)) to
+render the remarkable files to svg, converts them to pdf and then merges them together with, if necessary,
+the background pdf. _Currently, [Seb-sti1/rmc](https://github.com/Seb-sti1/rmc/tree/dev) is used because it
+uses [rmscene](https://github.com/ricklupton/rmscene) v0.5.0 instead of v0.2.0_
 
-I decided to make this app for `.content` version 1 and 2
-_(`"formatVersion": 2` or `"formatVersion": 1`)_, and
-to use [rmc](https://github.com/ricklupton/rmc) to render `.rm` v6.
+_Please before submitting an issue check the [Known issues](#known-issues) section and the already existing issues._
 
-_Currently [EelcovanVeldhuizen/rmc](https://github.com/EelcovanVeldhuizen/rmc@7cb02ef) is used because it
-uses [rmscene](https://github.com/ricklupton/rmscene) v0.4.0 instead of v0.2.0_
+## How to use?
 
-### How to check compatibility and update my files to v6?
+After installing the package in the python environment, it is intended to be used with the following commands:
 
+```sh
+# replace [ip] by the ip of the remarkable. 
+rsync -r --delete --progress root@[ip]:/home/root/.local/share/remarkable/xochitl/ rm_folder/
+python -m rmtree ./rm_folder ./exported_file_destination
+```
+
+## How to check compatibility and update my files to v6?
+
+[_Hopefully soon_](https://github.com/Seb-sti1/rmtree/issues/3)
 
 ## Known issues
 
-- `Unknown block type 13` or `Unknown block type 8`: Fix in [rmscene#24](https://github.com/ricklupton/rmscene/pull/24),
-  waiting for the version to be released.
+- [Background template aren't exactly aligned](https://github.com/Seb-sti1/rmc/issues/4)
+- [Missing background templates](https://github.com/Seb-sti1/rmtree/issues/4)
+  (`P Lines small`,  `P Grid medium`, `P Grid large`, `P Lines medium`, `P Checklist`)
+- `Unknown block type 13` or `Unknown block type 8`: Fixed
+  in [rmscene#24](https://github.com/ricklupton/rmscene/pull/24), waiting for the version to be released.
+- [`AssertionError` on `next_items` in `toposort_items`](https://github.com/ricklupton/rmscene/issues/32)
+
+## Contributions
+
+All contributions are welcomed :).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rmtree"
-version = "0.1.0"
+version = "0.2.0a"
 requires-python = ">=3.10"
 readme = "README.md"
-license = { file = "LICENSE.txt" }
+license = { file = "LICENSE" }
 
 description = "Convert the file tree from the reMarkable tablet to PDFs"
 authors = ["Seb-sti1"]
@@ -16,7 +16,8 @@ dependencies = [
     "fpdf2",
     "pypdf",
     "cairosvg",
-    "rmc@git+https://github.com/EelcovanVeldhuizen/rmc#egg=7cb02ef",
+    "rmc@git+https://github.com/Seb-sti1/rmc.git@bdb353feff968c9061fd4232699e58e95d4429db",
+    "rmscene",
     "tqdm",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fpdf2
 pypdf
 cairosvg
-rmc @ git+https://github.com/EelcovanVeldhuizen/rmc@7cb02ef
+rmc@git+https://github.com/Seb-sti1/rmc.git@bdb353feff968c9061fd4232699e58e95d4429db
 tqdm
-
+rmscene

--- a/rmtree/__main__.py
+++ b/rmtree/__main__.py
@@ -1,3 +1,4 @@
 from .main import main
 
-main()
+if __name__ == "__main__":
+    main()

--- a/rmtree/file.py
+++ b/rmtree/file.py
@@ -5,15 +5,20 @@ import logging
 import os
 import re
 import shutil
+import traceback
+import typing as tp
 from pathlib import Path
-from typing import Dict
 
 import cairosvg
 from pypdf import PdfReader, PdfWriter, Transformation
-from rmc.cli import convert_rm
+from rmc.exporters.svg import tree_to_svg, PAGE_WIDTH_PT, PAGE_HEIGHT_PT
+from rmscene import read_tree
 
 # id are formatted as 8-4-4-4-12 alphanumerical characters
 ID_PATTERN = re.compile(r"([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\.?.*")
+
+# svg viewBox
+SVG_VIEWBOX_PATTERN = re.compile(r"^<svg .+ viewBox=\"([\-\d.]+) ([\-\d.]+) ([\-\d.]+) ([\-\d.]+)\">$")
 
 # the header of a rm binary file, used to detect the version of the file
 RM_VERSION = "reMarkable .lines file, version="
@@ -21,14 +26,14 @@ RM_VERSION = "reMarkable .lines file, version="
 logger = logging.getLogger(__name__)
 
 
-class FileVersion:
+class PageType:
     V6 = 6
     V5 = 5
     V3 = 3
     EMPTY = 0
     UNKNOWN = -1
 
-    VALID_VERSIONS = [V6, V5, V3]
+    VALID_VERSIONS: list[PageType] = [V6, V5, V3]
 
 
 class FileType:
@@ -61,7 +66,7 @@ class File:
         self.parent = self.metadata["parent"] if self.metadata["parent"] != "" and not self.in_trash else None
         self.type = self.metadata["type"] if FileType.valid_type(self.metadata["type"]) else FileType.UNKNOWN
 
-    def get_path(self, files: Dict[str, File]) -> str:
+    def get_path(self, files: tp.Dict[str, File]) -> str:
         path = ""
 
         if self.parent is not None:
@@ -77,7 +82,7 @@ class File:
 
         return path
 
-    def get_fullpath(self, files: Dict[str, File]) -> str:
+    def get_fullpath(self, files: tp.Dict[str, File]) -> str:
         return str(os.path.join(self.get_path(files), self.name))
 
     def __str__(self):
@@ -100,18 +105,24 @@ class NotebookPage:
 
     def __init__(self, src: str, uid: str, notebook: Notebook, isContentVersion1: bool, definition: json):
         self.definition = definition
-        self.isContentVersion1 = isContentVersion1
         self.notebook = notebook
         self.uid = uid
         self.src = src
+        self.template = None
+        if not isContentVersion1 and "template" in definition:
+            self.template = None if definition["template"]["value"] == "Blank" else definition["template"]["value"]
+
+        self.pdf_page_idx = None
+        if not isContentVersion1:
+            self.pdf_page_idx = definition["redir"]["value"] if "redir" in definition else None
 
         self.path = os.path.join(self.src, self.notebook.uid, self.uid + ".rm")
-        self.version = FileVersion.UNKNOWN
+        self.version = PageType.UNKNOWN
 
         if not os.path.exists(self.path):
-            self.version = FileVersion.EMPTY
+            self.version = PageType.EMPTY
         else:
-            headers = {v: RM_VERSION + str(v) for v in FileVersion.VALID_VERSIONS}
+            headers = {v: RM_VERSION + str(v) for v in PageType.VALID_VERSIONS}
             with open(self.path, 'rb') as f:
                 file_header = f.read(max([len(headers[v]) for v in headers]))
                 for v in headers:
@@ -120,54 +131,73 @@ class NotebookPage:
                         self.version = v
                         break
 
-    def get_version(self):
+    def get_version(self) -> PageType:
         """
         :return: the version of the page
         """
         return self.version
 
-    def export(self, dst="/tmp") -> None | str:
+    def export(self, dst) -> (str, (float, float, float, float)):
         """
         Use rmc to convert a rm binary file to a svg
 
         :param dst: the destination path where to store the svg
-        :return:
+        :return: the path to the svg, and the x,y shift in the svg coordinates
         """
-
-        if self.get_version() == FileVersion.EMPTY:
-            return None
-
+        assert self.get_version() != PageType.EMPTY
         input_rm = Path(os.path.join(self.src, self.notebook.uid, self.uid + ".rm"))
         output_svg = os.path.join(dst, f"{self.uid}.svg")
 
-        with open(output_svg, "w") as fout:
-            convert_rm(input_rm, "svg", fout)
+        template = Path(os.path.join(Path(__file__).parent, "templates", self.template + ".svg")) \
+            if self.template is not None else None
 
-        return output_svg
+        if template is not None and not template.exists():
+            logger.warning(f"Can't find the specified template file ({template.name})")
+            template = None
+
+        with open(input_rm, 'rb') as f:
+            with open(output_svg, "w") as fout:
+                tree = read_tree(f)
+                tree_to_svg(tree, fout, template)
+
+        x_shift, y_shift, w, h = 0, 0, PAGE_WIDTH_PT, PAGE_HEIGHT_PT
+        with open(output_svg, "r") as svg:
+            found = False
+            for line in svg.readlines():
+                res = SVG_VIEWBOX_PATTERN.match(line)
+                if res is not None:
+                    x_shift, y_shift = float(res.group(1)), float(res.group(2))
+                    w, h = float(res.group(3)), float(res.group(4))
+                    found = True
+                    break
+
+            if not found:
+                logger.warning(f"Can't find x shift, y shift, width and height for {self.uid}")
+
+        return output_svg, (x_shift, y_shift, w, h)
 
 
 class Notebook(File):
     """
     A notebook is a file on the reMarkable that is a folder or a deleted file (tombstone/dirty). Currently, it can
     be anything from a pdf to a "drawing" only file.
-
-    TODO: deals with background of the remarkable
     """
 
     def __init__(self, src: str, uid: str):
         super().__init__(src, uid)
-        assert self.content["formatVersion"] in [1, 2]  # this software is only compatible with .content version 2 or 1
+        assert self.content["formatVersion"] in [1, 2], "this software is only compatible with .content version 2 or 1"
+        self.content_version = self.content["formatVersion"]
 
-        pages = self.content["cPages"]["pages"] if self.content["formatVersion"] == 2 else self.content["pages"]
+        pages = self.content["cPages"]["pages"] if self.content_version == 2 else self.content["pages"]
 
         self.pages: list[NotebookPage] = []
         for p in pages:
             if "deleted" not in p:
-                uid = p if self.content["formatVersion"] == 1 else p["id"]
-                p = NotebookPage(self.src, uid, self, self.content["formatVersion"] == 1, p)
+                uid = p if self.content_version == 1 else p["id"]
+                p = NotebookPage(self.src, uid, self, self.content_version == 1, p)
 
-                if p.get_version() != FileVersion.EMPTY:
-                    assert p.get_version() == FileVersion.V6  # this software is only compatible with .rm version 6
+                if p.get_version() != PageType.EMPTY:
+                    assert p.get_version() == PageType.V6, "this software is only compatible with .rm version 6"
 
                 self.pages.append(p)
             else:
@@ -175,56 +205,85 @@ class Notebook(File):
 
         assert self.content["pageCount"] == len(self.pages)
 
-    def export(self, dst: Path, files: Dict[str, File], debug=False):
+    def export(self, dst: Path, files: tp.Dict[str, File], debug=False):
         path = os.path.join(dst, self.get_path(files))
         fullpath = os.path.join(dst, self.get_fullpath(files))
 
+        # create the folder tree (if needed)
         os.makedirs(path, exist_ok=True)
 
-        svgs = []
-        for page in self.pages:
-            try:
-                svg = page.export("/tmp" if not debug else dst)
-                svgs.append(svg)
-            except Exception as e:
-                logger.warning(f"Failed to export {page.uid} of {self.uid}: {e}")
-
         if os.path.exists(os.path.join(self.src, self.uid + ".pdf")):
-            if all([svg is None for svg in svgs]):
+            if all([page == PageType.EMPTY for page in self.pages]):
                 # this is only a pdf
+                logger.debug(f"[pdf] {str(self)} -> {fullpath}")
                 shutil.copyfile(os.path.join(self.src, self.uid + ".pdf"), fullpath + ".pdf")
             else:
                 background = PdfReader(os.path.join(self.src, self.uid + ".pdf"))
                 output_pdf = PdfWriter()
-
-                for page_num, (page, svg) in enumerate(zip(background.pages, svgs)):
-                    if svg is not None:
-                        # use dpi=72 so that the pdf has the same size as the svg
-                        cairosvg.svg2pdf(url=svg, write_to=svg + ".pdf", dpi=72)
-                        # get the page
-                        svg_pdf = PdfReader(svg + ".pdf")
-                        assert len(svg_pdf.pages) == 1
-                        svg_pdf_p = svg_pdf.pages[0]
-                        # scale the page
-                        ratio = 856 / page.mediabox.height
-                        page.scale(ratio, ratio)
-                        # move it at the right place
-                        svg_pdf_p.merge_transformed_page(page,
-                                                         Transformation().translate(
-                                                             (svg_pdf_p.mediabox.width - page.mediabox.width) / 2,
-                                                             svg_pdf_p.mediabox.height - page.mediabox.height),
-                                                         over=False)
-                        output_pdf.add_page(svg_pdf_p)
+                # when file is content_version == 2, certain pages can use the background pdf while others are a
+                # regular background
+                reordered_background = background.pages if self.content_version == 1 \
+                    else [None if p.pdf_page_idx is None else background.pages[p.pdf_page_idx] for p in self.pages]
+                for page, background_page in zip(self.pages, reordered_background):
+                    if page.get_version() != PageType.EMPTY:
+                        try:
+                            # get the page as a pdf, use dpi=72 so that the pdf has the same resolution as the svg
+                            svg, (x_shift, y_shift, w_svg, h_svg) = page.export("/tmp" if not debug else dst)
+                            cairosvg.svg2pdf(url=svg, write_to=svg + ".pdf", dpi=72)
+                            svg_pdf = PdfReader(svg + ".pdf")
+                            assert len(svg_pdf.pages) == 1
+                            svg_pdf_p = svg_pdf.pages[0]
+                            # get size of the background_page
+                            w_bg = 0 if background_page is None else background_page.mediabox.width
+                            h_bg = 0 if background_page is None else background_page.mediabox.height
+                            # add a blank page that can contains both svg and background pdf
+                            width, height = max(w_svg, w_bg), max(h_svg, h_bg)
+                            new_page = output_pdf.add_blank_page(width, height)
+                            # compute position of svg and background in the new_page
+                            x_svg, y_svg = 0, 0
+                            x_bg, y_bg = 0, 0
+                            if w_svg > w_bg:
+                                x_bg = width / 2 - w_bg / 2 - (w_svg / 2 + x_shift)
+                            elif w_svg < w_bg:
+                                x_svg = width / 2 - w_svg / 2 + (w_svg / 2 + x_shift)
+                            if h_svg > h_bg:
+                                y_bg = height - h_bg + y_shift
+                            elif h_svg < h_bg:
+                                y_svg = height - h_svg - y_shift
+                            # merge background_page and svg_pdf_p
+                            if background_page is not None:
+                                new_page.merge_transformed_page(background_page,
+                                                                Transformation().translate(x_bg, y_bg))
+                            new_page.merge_transformed_page(svg_pdf_p,
+                                                            Transformation().translate(x_svg, y_svg))
+                        except Exception as e:
+                            logger.warning(f"Failed to export {page.uid} of {self.uid}:")
+                            traceback.print_exc()
                     else:
-                        output_pdf.add_page(page)
+                        output_pdf.add_page(background_page)
 
-                output_pdf.write(fullpath + ".pdf")
-                output_pdf.close()
+                if len(output_pdf.pages) > 0:
+                    output_pdf.write(fullpath + ".pdf")
+                    output_pdf.close()
+                else:
+                    logger.fatal(f"{fullpath + '.pdf'} is empty... It will not be exported to disk.")
         else:
+            # there is no background pdf
             merger = PdfWriter()
-            for svg in svgs:
-                if svg is not None:
-                    cairosvg.svg2pdf(url=svg, write_to=svg + ".pdf")
-                    merger.append(str(svg + ".pdf"))
-            merger.write(fullpath + ".pdf")
-            merger.close()
+            for page in self.pages:
+                if page.get_version() != PageType.EMPTY:
+                    try:
+                        svg, _ = page.export("/tmp" if not debug else dst)
+                        cairosvg.svg2pdf(url=svg, write_to=svg + ".pdf")
+                        merger.append(svg + ".pdf")
+                    except Exception as e:
+                        logger.warning(f"Failed to export {page.uid} of {self.uid}:")
+                        traceback.print_exc()
+                else:
+                    logger.info(f"{page.uid} of {self.uid} is empty... Discarding it.")
+
+            if len(merger.pages) > 0:
+                merger.write(fullpath + ".pdf")
+                merger.close()
+            else:
+                logger.fatal(f"{fullpath + '.pdf'} is empty... It will not be exported to disk.")

--- a/rmtree/main.py
+++ b/rmtree/main.py
@@ -1,8 +1,13 @@
 import argparse
+import json
+import logging
+import os
+import typing as tp
+from pathlib import Path
 
 from tqdm import tqdm
 
-from .file import *
+from .file import Folder, File, FileType, Notebook, ID_PATTERN
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +55,7 @@ def get_file_by_id(src: str, uid: str) -> File | None:
         return Notebook(src, uid)
 
 
-def list_files(src: str) -> Dict[str, File]:
+def list_files(src: str) -> tp.Dict[str, File]:
     """
     List the reMarkable file from the src folder. One reMarkable file can be composed of multiple actual files:
 
@@ -90,9 +95,9 @@ def main(args=None):
     # set up the logging
     level = logging.WARN
     if args.verbose == 1:
-        level = logging.DEBUG
-    elif args.verbose >= 2:
         level = logging.INFO
+    elif args.verbose >= 2:
+        level = logging.DEBUG
     logging.basicConfig(level=level)
 
     # print debug information on the files

--- a/rmtree/templates/P Grid small.svg
+++ b/rmtree/templates/P Grid small.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 200 200">
+    <defs>
+        <pattern id="template" x="-5" y="4" width="16" height="16" patternUnits="userSpaceOnUse">
+            <rect style="fill:rgb(255,255,255);stroke-width:.4;stroke:rgb(150,150,150)" x1="0" y1="0" width="16" height="16"/>
+        </pattern>
+    </defs>
+    <rect fill="url(#template)" x="25" y="25" width="150" height="150"/>
+</svg>


### PR DESCRIPTION
- [x] x, y shift
- [x] deals with remarkable background
- [x] finish https://github.com/Seb-sti1/rmc/pull/2
   - [x] Add small margin to ensure 1. the svg are always bigger than background pdf 2. line are not trimmed by the edge
- [x] ~~ new PR https://github.com/Seb-sti1/rmc/ ~~ -> https://github.com/Seb-sti1/rmc/issues/5
- [x] ~~option list non-compatible files~~ ->
- [x] ~~tests~~
- [x] README usages
- [x] used a fixed version in rmc url
- [x] last fixes
  - [x] FIXME deal with "new page" in pdf
  - [x] FIXME merge background page and svg
  - [x] FIXME prevent empty pdf export
   